### PR TITLE
Add Support For Version Flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,18 @@
+use std::env;
+
 fn main() {
-    println!("Hello, world!");
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        println!("WIP");
+        return;
+    }
+
+    let option_arg = &args[1];
+
+    if option_arg == "-v" || option_arg == "--version" {
+        println!("Version 0.1");
+    } else {
+        println!("Invalid option {}", option_arg);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ fn main() {
     let option_arg = &args[1];
 
     if option_arg == "-v" || option_arg == "--version" {
-        println!("Version 0.1");
+        println!("rost_gen version 0.1");
     } else {
         println!("Invalid option {}", option_arg);
     }


### PR DESCRIPTION
Added support for '-v' and '--version' flags. 
These will print out the name and version of the tool. For example, 'rost_gen version 0.1'