### PR TITLE
Add Support For Help Flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -12,6 +12,11 @@ fn main() {
 
     if option_arg == "-v" || option_arg == "--version" {
         println!("rost_gen version 0.1");
+    } else if option_arg == "-h" || option_arg == "--help" {
+        println!("Usage: rost_gen [OPTIONS]");
+        println!("Options:");
+        println!("\t-v, --version\t\t\tPrint the tool name and version");
+        println!("\t-h, --help\t\t\tPrint help message");
     } else {
         println!("Invalid option {}", option_arg);
     }


### PR DESCRIPTION
Add support for '-h' and '--help' flags.
Using either of these will print a help message to the console with the available options.