### PR TITLE
Check for no input path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,8 @@ fn print_help_message() {
 }
 
 fn handle_conversion(args: &Vec<String>) {
-    if args.len() > 3 {
-        println!("Please provide a single file or folder path. Enclose paths with spaces in single quotes");
+    if args.len() != 3 {
+        println!("Please provide a file or folder path. Enclose paths with spaces in single quotes");
         return;
     }
 


### PR DESCRIPTION
Print out an error message if the user uses the ``-i`` flag but doesn't specify an input path