### PR TITLE
Make html title tags appear on their own lines

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use std::io::{self, BufRead, Seek, Write};
 use std::{fs, path};
 
-const HTML_TEMPLATE: &str = "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n\t<meta charset=\"UTF-8\">\n\t<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">\n\t<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\t<title>\n\t\t{{title}}\t</title>\n</head>\n<body>\n";
+const HTML_TEMPLATE: &str = "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n\t<meta charset=\"UTF-8\">\n\t<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">\n\t<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n\t<title>\n\t\t{{title}}\n\t</title>\n</head>\n<body>\n";
 const DEFAULT_OUTPUT_DIR: &str = "./dist";
 
 #[derive(Parser)]


### PR DESCRIPTION
Title tags should appear on their own lines:  

<img width="600" alt="title tags on their own lines" src="https://user-images.githubusercontent.com/67077705/193364145-33b497ca-5de1-406f-826b-d0cb4e391e2a.png">
