### PR TITLE
40 - Add Markdown Support For Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ This will create the optimized build in the ./target/release directory. Run the 
     Second line of second paragraph
   </p>
   ```
-- ### Header detection for .md files  
+  
+# Markdown (.md) File Features
+- ### Header detection
   ```
   # This line is header
   ```
@@ -79,14 +81,25 @@ This will create the optimized build in the ./target/release directory. Run the 
   </h1>
   ```
   
-- ### Thematic Break detection (horizontal rule) for .md files
-  ```txt
+- ### Thematic Break detection (horizontal rule)
+  ```
   ---
   ```
   will be converted into
   ```html
   <hr />
   ```
+  This is only supported for lines that just have the above markdown text
+  
+- ### Link Markdown
+  ```
+  [This is a link](https://www.example.com)
+  ```
+  will be converted to 
+  ```html
+  <a href="https://www.example.com">This is a link</a>
+  ```
+  Any text before or after the markdown in the same line will be preserved as is
 
 # Examples
 - ### One input file

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,6 +257,7 @@ fn conversion_file_path_valid(path: &path::Path) -> bool {
 }
 
 fn process_link_markdown(line: &String) -> String {
+    const LINK_HTML_TEMPLATE : &str = "<a href=\"URL\">TEXT</a>";
     let line_bytes = line.as_bytes();
     let mut link_start_found = false;
     let mut link_end_found = false;
@@ -291,7 +292,29 @@ fn process_link_markdown(line: &String) -> String {
         }
     }
 
+    if link_start_found && link_end_found {
+        let link_text = &line[link_start..link_end];
+        println!("Link Text: {link_text}");
+        let mut link_url = "";
+        let mut link_html = LINK_HTML_TEMPLATE.replace("TEXT", link_text);
 
+        if link_url_start_found && link_url_end_found {
+            link_url = &line[link_url_start..link_url_end];
+            println!("Link URL: {link_url}");
+        }
+
+        link_html = link_html.replace("URL", link_url);
+        
+        if link_start > 1 {
+            link_html = format!("{} {link_html}", &line[0..(link_start-1)]);
+        }
+
+        if (link_end + 1) < (line_bytes.len() - 1) {
+            link_html = format!("{link_html} {}", &line[(link_end + 1)..]);
+        }
+
+        return link_html.clone();
+    }
 
     return line.clone();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,10 +289,6 @@ fn process_link_markdown(line: &String) -> String {
                 link_url_end = i;
             }
         }
-
-        if link_start_found && link_end_found && char == b')' {
-            
-        }
     }
 
     return line.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,18 +276,18 @@ fn process_link_markdown(line: &String) -> String {
 
         if link_start_found && !link_end_found && char == b']' {
             link_end_found = true;
-            link_end = i - 1;
+            link_end = i;
         }
 
-        if link_start_found && link_end_found {
+        if link_end_found {
             if !link_url_start_found && char == b'(' {
                 link_url_start_found = true;
                 link_url_start = i + 1;
             }
 
-            if link_url_end_found && !link_url_end_found && char == b')' {
+            if link_url_start_found && !link_url_end_found && char == b')' {
                 link_url_end_found = true;
-                link_url_end = i - 1;
+                link_url_end = i;
             }
         }
     }
@@ -309,7 +309,7 @@ fn process_link_markdown(line: &String) -> String {
             link_html = format!("{} {link_html}", &line[0..(link_start-1)]);
         }
 
-        if (link_end + 1) < (line_bytes.len() - 1) {
+        if (link_end + 1) < line_bytes.len() {
             link_html = format!("{link_html} {}", &line[(link_end + 1)..]);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,13 +294,11 @@ fn process_link_markdown(line: &String) -> String {
 
     if link_start_found && link_end_found {
         let link_text = &line[link_start..link_end];
-        println!("Link Text: {link_text}");
         let mut link_url = "";
         let mut link_html = LINK_HTML_TEMPLATE.replace("TEXT", link_text);
 
         if link_url_start_found && link_url_end_found {
             link_url = &line[link_url_start..link_url_end];
-            println!("Link URL: {link_url}");
         }
 
         link_html = link_html.replace("URL", link_url);

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,5 +257,14 @@ fn conversion_file_path_valid(path: &path::Path) -> bool {
 }
 
 fn process_line_markdown(line: &String) -> String {
+    let line_bytes = line.as_bytes();
+    let mut link_start_found = false;
+
+    for (i, &char) in line_bytes.iter().enumerate() {
+        if char == b'[' {
+            link_start_found = true;
+        } 
+    }
+
     return line.clone();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,7 @@ fn convert_file(
             } else if read_buffer == "---\n" || read_buffer == "---\r\n" {
                 write!(out_file, "<hr />\n").expect("Generate html file");
             } else {
-                let processed_line = process_line_markdown(&read_buffer);
+                let processed_line = process_link_markdown(&read_buffer);
                 write!(out_file, "\t\t{}", processed_line.clone()).expect("Generate html file");
             }
         }
@@ -256,14 +256,43 @@ fn conversion_file_path_valid(path: &path::Path) -> bool {
     return false;
 }
 
-fn process_line_markdown(line: &String) -> String {
+fn process_link_markdown(line: &String) -> String {
     let line_bytes = line.as_bytes();
     let mut link_start_found = false;
+    let mut link_end_found = false;
+    let mut link_url_start_found = false;
+    let mut link_url_end_found = false;
+    let mut link_start = 0;
+    let mut link_end = 0;
+    let mut link_url_start = 0;
+    let mut link_url_end = 0;
 
     for (i, &char) in line_bytes.iter().enumerate() {
-        if char == b'[' {
+        if !link_start_found && char == b'[' {
             link_start_found = true;
-        } 
+            link_start = i;
+        }
+
+        if link_start_found && !link_end_found && char == b']' {
+            link_end_found = true;
+            link_end = i;
+        }
+
+        if link_start_found && link_end_found {
+            if !link_url_start_found && char == b'(' {
+                link_url_start_found = true;
+                link_url_start = i;
+            }
+
+            if link_url_end_found && !link_url_end_found && char == b')' {
+                link_url_end_found = true;
+                link_url_end = i;
+            }
+        }
+
+        if link_start_found && link_end_found && char == b')' {
+            
+        }
     }
 
     return line.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,11 +306,11 @@ fn process_link_markdown(line: &String) -> String {
         link_html = link_html.replace("URL", link_url);
         
         if link_start > 1 {
-            link_html = format!("{} {link_html}", &line[0..(link_start-1)]);
+            link_html = format!("{}{link_html}", &line[0..(link_start-1)]);
         }
 
-        if (link_end + 1) < line_bytes.len() {
-            link_html = format!("{link_html} {}", &line[(link_end + 1)..]);
+        if (link_url_end + 1) < line_bytes.len() {
+            link_html = format!("{link_html}{}", &line[(link_url_end + 1)..]);
         }
 
         return link_html.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,26 +270,28 @@ fn process_link_markdown(line: &String) -> String {
     for (i, &char) in line_bytes.iter().enumerate() {
         if !link_start_found && char == b'[' {
             link_start_found = true;
-            link_start = i;
+            link_start = i + 1;
         }
 
         if link_start_found && !link_end_found && char == b']' {
             link_end_found = true;
-            link_end = i;
+            link_end = i - 1;
         }
 
         if link_start_found && link_end_found {
             if !link_url_start_found && char == b'(' {
                 link_url_start_found = true;
-                link_url_start = i;
+                link_url_start = i + 1;
             }
 
             if link_url_end_found && !link_url_end_found && char == b')' {
                 link_url_end_found = true;
-                link_url_end = i;
+                link_url_end = i - 1;
             }
         }
     }
+
+
 
     return line.clone();
 }


### PR DESCRIPTION
Added the following markdown support for internal or external links:

```
[Link Text](Link Url)
```
This will get converted to 
```html
<a href="Link Url">Link Text</a>
```

Supports inline links and links on their own line. Any text before or after the link on the same line is preserved